### PR TITLE
RoleProvider refactor to use SecurityRegistry instance

### DIFF
--- a/lib/RoleProvider.js
+++ b/lib/RoleProvider.js
@@ -8,7 +8,7 @@ var Errors = require('./Errors');
  * @param {String} profileName  [description]
  * @param {String} resourceName [description]
  */
-function RoleProvider (profileName, resourceName, implementation) {
+function RoleProvider (profileName, resourceName, implementation, securityRegistry) {
 
   // Pre-conditions
   if (_.isString(profileName) === false) {
@@ -36,6 +36,12 @@ function RoleProvider (profileName, resourceName, implementation) {
   this.implementation = implementation || {};
 
   /**
+   * Security Registry instance
+   * @type {SecurityRegistry}
+   */
+  this._securityRegistry = securityRegistry || null;
+
+  /**
    * Set the implementation after construction
    * @param {Object} implementation [description]
    */
@@ -49,6 +55,22 @@ function RoleProvider (profileName, resourceName, implementation) {
    */
   this.getImplementation = function() {
     return this.implementation;
+  };
+
+  /**
+   * Set the Security Registry
+   * @param {SecurityRegistry} securityRegistry [description]
+   */
+  this.setSecurityRegistry = function(securityRegistry) {
+    this._securityRegistry = securityRegistry;
+  };
+
+  /**
+   * Get the SecurityRegistry
+   * @return {SecurityRegistry} [description]
+   */
+  this.getSecurityRegistry = function() {
+    return this._securityRegistry;
   };
 
   /**
@@ -85,14 +107,34 @@ function RoleProvider (profileName, resourceName, implementation) {
    * @param  {Function} cb       callback with prototype (err, Array)
    */
   this.allRoles = function(profile, resource, cb) {
+    var self = this;
     if (preconditions(profile, resource, cb) === false) {
       return;
     }
-    if (this.implementation.allRoles !== undefined) {
-      this.implementation.allRoles(this, profile, resource, function(err, roles) {
+    if (self.implementation.allRoles !== undefined) {
+      self.implementation.allRoles(self, profile, resource, function(err, roles) {
         if (err) {
           cb(err);
         } else {
+          // Check return type
+          if (_.isArray(roles) === false) {
+            cb(new Errors.PermissionArchitectRoleProviderError('Expected roles returned by implementation.allRoles to be Array'));
+            return;
+          }
+          // Check that items in roles are Role instances
+          for(var i = 0; i < roles.length; i++) {
+            if (roles[i] instanceof self._securityRegistry.Models.Role) {
+              // pass
+            } else {
+              err = new Errors.PermissionArchitectRoleProviderError('Expected roles array to contain Role instances');
+              break;
+            }
+          }
+          if (err) {
+            cb(err);
+            return;
+          }
+
           //@TODO sort roles
           cb(null, roles);
         }

--- a/lib/SecurityRegistry.js
+++ b/lib/SecurityRegistry.js
@@ -163,8 +163,8 @@ function SecurityRegistry(name) {
    * @param  {object} context       [description]
    * @return {RoleProvider}              [description]
    */
-  this.buildRoleProvider = function(profileName, resourceName, context) {
-    var roleProvider = new RoleProvider(profileName, resourceName, context);
+  this.buildRoleProvider = function(profileName, resourceName, implementation) {
+    var roleProvider = new RoleProvider(profileName, resourceName, implementation, this);
     this.log('trace', 'Built RoleProvider: %s => %s', profileName, resourceName);
     return roleProvider;
   };
@@ -253,8 +253,6 @@ function SecurityRegistry(name) {
       roleProvider.allRoles(profile, resource, function(err, roles) {
         if (err) {
           cb(err);
-        } else if (roles === undefined || roles === null) {
-          cb(null, [self.getFallbackRole()]);
         } else {
           cb(null, roles);
         }

--- a/specs/SecurityRegistrySpec.js
+++ b/specs/SecurityRegistrySpec.js
@@ -189,8 +189,12 @@ describe("SecurityRegistry", function() {
       expect(instance.resourceName).toBe("ResourceName");
     });
 
-    it("config is set", function() {
+    it("implementation is set", function() {
       expect(instance.getImplementation()).toEqual(implementation);
+    });
+
+    it('sets securityRegistry', function() {
+      expect(instance.getSecurityRegistry()).toEqual(securityRegistry);
     });
   });
 
@@ -305,30 +309,16 @@ describe("SecurityRegistry", function() {
       });
     });
 
-    it('returns fallback role if RoleProvider returns null', function(done) {
-      var roleProvider = securityRegistry.buildRoleProvider('User', 'Page', {
-        allRoles: function(provider, profile, resource, cb) {
-          setImmediate(cb, null, null);
-        }
-      });
-      securityRegistry.registerRoleProvider(roleProvider);
-      securityRegistry.rolesFor(profile, resource, function(err, role) {
-        expect(err).toBe(null);
-        expect(role).toEqual([securityRegistry.getFallbackRole()]);
-        done();
-      });
-    });
-
     it('returns role provided from RoleProvider', function(done) {
       var roleProvider = securityRegistry.buildRoleProvider('User', 'Page', {
         allRoles: function(provider, profile, resource, cb) {
-          setImmediate(cb, null, ['admin']);
+          setImmediate(cb, null, [provider.getSecurityRegistry().buildRole('admin')]);
         }
       });
       securityRegistry.registerRoleProvider(roleProvider);
-      securityRegistry.rolesFor(profile, resource, function(err, role) {
+      securityRegistry.rolesFor(profile, resource, function(err, roles) {
         expect(err).toBe(null);
-        expect(role).toEqual(['admin']);
+        expect(roles[0].name).toEqual('admin');
         done();
       });
     });
@@ -350,30 +340,16 @@ describe("SecurityRegistry", function() {
       });
     });
 
-    it('returns fallback role if RoleProvider returns null', function(done) {
-      var roleProvider = securityRegistry.buildRoleProvider('User', 'Page', {
-        allRoles: function(provider, profile, resource, cb) {
-          setImmediate(cb, null, null);
-        }
-      });
-      securityRegistry.registerRoleProvider(roleProvider);
-      securityRegistry.bestRoleFor(profile, resource, function(err, role) {
-        expect(err).toBe(null);
-        expect(role).toEqual(securityRegistry.getFallbackRole());
-        done();
-      });
-    });
-
     it('returns role provided from RoleProvider', function(done) {
       var roleProvider = securityRegistry.buildRoleProvider('User', 'Page', {
         bestRole: function(provider, profile, resource, cb) {
-          setImmediate(cb, null, 'admin');
+          setImmediate(cb, null, provider.getSecurityRegistry().buildRole('admin'));
         }
       });
       securityRegistry.registerRoleProvider(roleProvider);
       securityRegistry.bestRoleFor(profile, resource, function(err, role) {
         expect(err).toBe(null);
-        expect(role).toEqual('admin');
+        expect(role.name).toEqual('admin');
         done();
       });
     });


### PR DESCRIPTION
RoleProvider set/get for securityRegistry.
SecurityRegistry builds RoleProvider with instance of self set.
Important! Removed fallback role support with `rolesFor` and `bestRoleFor`

closes #23 
